### PR TITLE
Add github run url to Allure report

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -133,6 +133,12 @@ runs:
         fi
         echo "LIFETIME=$LIFETIME" >> $GITHUB_ENV
 
+    - name: Add github run url to Allure report
+      shell: bash
+      run: |
+        touch ${{ inputs.ALLURE_RESULTS_DIR }}/environment.properties
+        sed -i '1s|^|GITHUB_WORKFLOW_URL=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\n|' ${{ inputs.ALLURE_RESULTS_DIR }}/environment.properties
+
     - name: Generate Allure report
       uses: simple-elf/allure-report-action@v1.6
       if: always()


### PR DESCRIPTION
This will add a backlink to the workflow test run on top of the Allure report's "Environment" section. 