### PR TITLE
workflows: use macos-latest instead of macos-14

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [{runner: 'ubuntu-latest'}, {runner: 'macos-14'}]
+        os: [{runner: 'ubuntu-latest'}, {runner: 'macos-latest'}]
     timeout-minutes: 500
     steps:
       - name: Checkout gh-push-allure-report-to-neofs


### PR DESCRIPTION
No reason to pick macos-14 and it's somewhat outdated now. Follow https://github.com/nspcc-dev/.github/blob/6c4dff04862ad947805e82fb9b664899906c6305/gh.md.