### PR TITLE
.github: upgrade actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
     timeout-minutes: 500
     steps:
       - name: Checkout gh-push-allure-report-to-neofs
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Run gh-push-allure-report-to-neofs
         id: gh_push_allure_report_to_neofs


### PR DESCRIPTION
Fetch fresh version of some GH actions to avoid deprecated Node.js warnings.