### PR TITLE
.github: update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
-*   @vvarg229
+*   @roman-khimov
+*   @evgeniiz321


### PR DESCRIPTION
Unfortunately, @vvarg229 is not a part of NSPCC anymore, so it's not very nice of us to disturb him on every PR in this repo.